### PR TITLE
Fix usage of ClassWriter

### DIFF
--- a/src/main/java/com/mrnobody/morecommands/asm/WriterTransformer.java
+++ b/src/main/java/com/mrnobody/morecommands/asm/WriterTransformer.java
@@ -8,13 +8,12 @@ import org.objectweb.asm.Opcodes;
 /**
  * The abstract {@link Transformer} for transformations using the visitor based
  * api of the objectweb ASM library
- * 
+ *
  * @author MrNobody98
  */
 public abstract class WriterTransformer extends ClassVisitor implements Transformer {
 	public WriterTransformer() {
 		super(Opcodes.ASM5);
-		this.cv = new ClassWriter(this.getWriteFlags());
 	}
 
 	/**
@@ -23,27 +22,29 @@ public abstract class WriterTransformer extends ClassVisitor implements Transfor
 	@Override
 	public final byte[] transform(String name, String transformedName, byte[] basicClass) {
 		if (!this.getTransformClassNames().contains(transformedName)) return basicClass;
-		
+
 		MoreCommandsLoadingPlugin.logger.info("Transforming class " + transformedName);
-		
+
+		this.cv = new ClassWriter(this.getWriteFlags());
+
 		this.beforeTransform();
-		
+
 		this.setCurrentClassName(transformedName);
 		ClassReader cr = new ClassReader(basicClass);
 		cr.accept(this, this.getReadFlags());
-		
+
 		this.afterTransform();
-		
+
 		return ((ClassWriter) this.cv).toByteArray();
 	}
-	
+
 	/**
 	 * Invoked before a class transformations. Sets the name of the class being transformed
-	 * 
+	 *
 	 * @param name the name of the class whose transformations begins after invoking this method
 	 */
 	public abstract void setCurrentClassName(String name);
-	
+
 	/**
 	 * {@inheritDoc}
 	 */
@@ -51,7 +52,7 @@ public abstract class WriterTransformer extends ClassVisitor implements Transfor
 	public int getReadFlags() {
 		return 0;
 	}
-	
+
 	/**
 	 * {@inheritDoc}
 	 */


### PR DESCRIPTION
Currently, a `ClassWriter` instance is shared between invocations of `transform`. When [SpongeForge](https://github.com/SpongePowered/SpongeForge) or another coremod which uses [Mixin](https://github.com/SpongePowered/Mixin) is installed, mod-provided transformers can be called multiple times for a given class. Since the `ClassWriter` is re-used, duplicate fields and methods end up being present in the generated bytecode the second time `transform` is called.

This PR changes `WriterTransformer` to use a new `ClassWriter` each time `transform` is called, solving this issue.